### PR TITLE
include missing <cstdint> to support gcc-13

### DIFF
--- a/lib/TinyEXIF/TinyEXIF.h
+++ b/lib/TinyEXIF/TinyEXIF.h
@@ -34,6 +34,7 @@
 #ifndef __TINYEXIF_H__
 #define __TINYEXIF_H__
 
+#include <cstdint>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
gcc 13 moved some includes around and as a result <cstdint> is no longer transitively included [1]. Explicitly include it for uint{32,64}_t.

[1] https://gcc.gnu.org/gcc-13/porting_to.html#header-dep-changes