### PR TITLE
HeifPicture.cpp: fix build error

### DIFF
--- a/src/HeifPicture.cpp
+++ b/src/HeifPicture.cpp
@@ -187,7 +187,7 @@ bool HeifPicture::Decode(uint8_t* pixels,
     return false;
   }
 
-  int stride;
+  size_t stride;
   const uint8_t* data = img.get_plane(heif_channel_interleaved, &stride);
   if (!data)
     return false;


### PR DESCRIPTION
kodi-imagedecoder-heif-22.0.1-Piers/src/HeifPicture.cpp:191:38:
 error: no matching function for call to 'heif::Image::get_plane(heif_channel, int*)'
  191 |   const uint8_t* data = img.get_plane(heif_channel_interleaved, &stride);

kodi-imagedecoder-heif/host/x86_64-buildroot-linux-gnu/sysroot/usr/include/libheif/heif_cxx.h:909:25:
 note: candidate 1: 'const uint8_t* heif::Image::get_plane(heif_channel, size_t*) const'

Build error occured with

-- The C compiler identification is GNU 15.2.0
-- The CXX compiler identification is GNU 15.2.0

and libheif 1.20.1.