### PR TITLE
Fix build with system libheif >= 1.20.0

### DIFF
--- a/src/HeifPicture.cpp
+++ b/src/HeifPicture.cpp
@@ -187,8 +187,16 @@ bool HeifPicture::Decode(uint8_t* pixels,
     return false;
   }
 
+#if LIBHEIF_HAVE_VERSION(1,20,2)
+  size_t stride;
+  const uint8_t* data = img.get_plane2(heif_channel_interleaved, &stride);
+#elif LIBHEIF_HAVE_VERSION(1,20,0)
+  size_t stride;
+  const uint8_t* data = img.get_plane(heif_channel_interleaved, &stride);
+#else
   int stride;
   const uint8_t* data = img.get_plane(heif_channel_interleaved, &stride);
+#endif
   if (!data)
     return false;
 


### PR DESCRIPTION
A change occurred in the libheif API for versions 1.20.0 and 1.20.1, which is incompatible with versions 1.19 and >= 1.20.2

Starting from libheif 1.20.2, it is recommended to use the non-deprecated function heif_image_get_plane2()

This patch fixes the compilation of the addon that uses the system versions of libheif.

The fix has been tested on Gentoo Linux with media-libs/libheif 1.19.8, 1.20.1, and 1.20.2.

See:
Upstream issue: https://github.com/strukturag/libheif/issues/1566
User-reported issue: https://github.com/kodi-overlay/kodi-overlay/issues/14 