### PR TITLE
Fix memory leak in HEIF image decoder

### DIFF
--- a/src/HeifPicture.cpp
+++ b/src/HeifPicture.cpp
@@ -43,6 +43,9 @@ bool HeifPicture::ReadTag(const std::string& file, kodi::addon::ImageDecoderInfo
   std::vector<uint8_t> buffer(length);
   fileData.Read(buffer.data(), buffer.size());
 
+  // Create a new context for each read to prevent memory leaks
+  m_heifCtx = std::make_unique<heif::Context>();
+
   try
   {
     m_heifCtx->read_from_memory_without_copy(buffer.data(), buffer.size());
@@ -149,6 +152,9 @@ bool HeifPicture::LoadImageFromMemory(const std::string& mimetype,
                                       unsigned int& width,
                                       unsigned int& height)
 {
+  // Create a new context for each load to prevent memory leaks
+  m_heifCtx = std::make_unique<heif::Context>();
+
   try
   {
     m_heifCtx->read_from_memory_without_copy(buffer, bufSize);


### PR DESCRIPTION
The HeifPicture class was reusing the same heif::Context object across multiple image loads, causing it to accumulate image data without ever releasing previous images. This resulted in unbounded memory growth when viewing multiple HEIF images in sequence.

The fix creates a fresh heif::Context for each image load in both ReadTag() and LoadImageFromMemory(), ensuring that old image data is properly released when the previous unique_ptr is reset.

This resolves the memory balloon issue where memory usage would grow continuously as users browsed through HEIF image galleries.