### PR TITLE
Do not require libde265 at configure time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,8 @@ project(imagedecoder.heif)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR})
 
 find_package(Kodi REQUIRED)
-find_package(de265 REQUIRED)
+# optional: system libheif may provide HEVC itself; still linked when found for static builds
+find_package(de265)
 find_package(HEIF REQUIRED)
 find_package(Threads REQUIRED)
 find_package(TinyXML2 REQUIRED)


### PR DESCRIPTION
`src/` includes `kodi/addon-instance/ImageDecoder.h`, `libheif/heif_cxx.h` and TinyEXIF — never `libde265/de265.h`. `git log -S libde265 -- src/ lib/` returns nothing, so the `REQUIRED` has been vestigial for the life of the add-on.

It does have a cost: it prevents configuring against a system libheif that supplies HEVC on its own. freedesktop-sdk 26.08 ships libheif 1.23.1 with plugin loading enabled and provides `libheif-libde265.so` through the `codecs-extra` extension; Debian splits the decoder out into `libheif-plugin-libde265` the same way. In those environments libde265 need not be visible to this add-on at all.

This only drops `REQUIRED`. `${de265_INCLUDE_DIRS}` and `${de265_LIBRARIES}` are left in place, so wherever libde265 is found — including Kodi's own depends builds, where `FindHEIF.cmake` resolves a static libheif and cannot pick up transitive libraries from pkg-config — the include path and link line are byte-for-byte unchanged.

**Testing:** built in the Flathub `tv.kodi.Kodi` manifest against freedesktop-sdk 26.08 with the bundled libheif and libde265 modules removed. The resulting `imagedecoder.heif.so` lists only `libheif.so.1` (plus tinyxml2 and libc) in `DT_NEEDED`. Four HEIC images display correctly in Kodi 22: 4032×3024 and 4000×3000 grid-tiled files of 48 HEVC tiles each, 8-bit 4:2:0, profiles Main and Main Still Picture, exercising tile assembly, embedded thumbnails, EXIF and `irot` rotation.
